### PR TITLE
Update Coreweave provider to use the kubeconfig used by autoscaler

### DIFF
--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider_test.go
@@ -96,13 +96,6 @@ func (f *fakeManager) Refresh() error {
 	return nil
 }
 
-func TestNewCoreWeaveCloudProvider_NilManager(t *testing.T) {
-	cp := NewCoreWeaveCloudProvider(nil)
-	if cp != nil {
-		t.Errorf("expected nil provider, got %v", cp)
-	}
-}
-
 func TestCoreWeaveCloudProvider_Name(t *testing.T) {
 	cp := &CoreWeaveCloudProvider{}
 	if cp.Name() != cloudprovider.CoreWeaveProviderName {

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_utils.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_utils.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,35 +43,27 @@ var CoreWeaveNodeGroupResource = schema.GroupVersionResource{
 	Resource: coreWeaveResource,
 }
 
-var inClusterConfig = rest.InClusterConfig
-
-// GetCoreWeaveClient returns a Kubernetes client for CoreWeave
-func GetCoreWeaveClient() (kubernetes.Interface, error) {
-	config, err := inClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get in-cluster config: %v", err)
+// GetCoreWeaveClient returns a Kubernetes client for CoreWeave using the provided rest.Config
+func GetCoreWeaveClient(config *rest.Config) (kubernetes.Interface, error) {
+	if config == nil {
+		return nil, fmt.Errorf("rest.Config is nil")
 	}
-
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
-
 	return clientset, nil
 }
 
-// GetCoreWeaveDynamicClient returns a dynamic client for CoreWeave
-func GetCoreWeaveDynamicClient() (dynamic.Interface, error) {
-	config, err := inClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get in-cluster config: %v", err)
+// GetCoreWeaveDynamicClient returns a dynamic client for CoreWeave using the provided rest.Config
+func GetCoreWeaveDynamicClient(config *rest.Config) (dynamic.Interface, error) {
+	if config == nil {
+		return nil, fmt.Errorf("rest.Config is nil")
 	}
-
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
 	}
-
 	return dynamicClient, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_utils_test.go
@@ -17,38 +17,26 @@ limitations under the License.
 package coreweave
 
 import (
-	"errors"
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
 )
 
-// --- Test GetCoreWeaveClient and GetCoreWeaveDynamicClient ---
-
-func TestGetCoreWeaveClient_InClusterConfigError(t *testing.T) {
-	orig := inClusterConfig
-	defer func() { inClusterConfig = orig }()
-	inClusterConfig = func() (*rest.Config, error) {
-		return nil, errors.New("mock error")
-	}
-	_, err := GetCoreWeaveClient()
-	if err == nil {
-		t.Error("expected error, got nil")
+func TestGetCoreWeaveClient(t *testing.T) {
+	// Nil config should return error
+	client, err := GetCoreWeaveClient(nil)
+	if err == nil || client != nil {
+		t.Error("expected error and nil client for nil config")
 	}
 }
 
-func TestGetCoreWeaveDynamicClient_InClusterConfigError(t *testing.T) {
-	orig := inClusterConfig
-	defer func() { inClusterConfig = orig }()
-	inClusterConfig = func() (*rest.Config, error) {
-		return nil, errors.New("mock error")
-	}
-	_, err := GetCoreWeaveDynamicClient()
-	if err == nil {
-		t.Error("expected error, got nil")
+func TestGetCoreWeaveDynamicClient(t *testing.T) {
+	// Nil config should return error
+	client, err := GetCoreWeaveDynamicClient(nil)
+	if err == nil || client != nil {
+		t.Error("expected error and nil client for nil config")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
update kubeconfig to use kube_util.GetKubeConfig(opts.KubeClientOpts)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
no
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
