### PR TITLE
bugfix : Coreweave nodegroups needs to be  empty slice instead of nil

### DIFF
--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager.go
@@ -122,7 +122,7 @@ func (m *CoreWeaveManager) UpdateNodeGroup() ([]cloudprovider.NodeGroup, error) 
 	// If no node pools are found, return an empty slice
 	if len(nodepools) == 0 {
 		klog.Info("No node pools found, returning empty node groups")
-		return nil, nil
+		return []cloudprovider.NodeGroup{}, nil
 	}
 	klog.V(4).Infof("Found %d node pools", len(nodepools))
 	m.nodeGroups = make([]cloudprovider.NodeGroup, len(nodepools))

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager.go
@@ -70,7 +70,8 @@ func (m *CoreWeaveManager) ListNodePools() ([]*CoreWeaveNodePool, error) {
 		return nil, fmt.Errorf("failed to list nodepools: %v", err)
 	}
 	if list == nil || len(list.Items) == 0 {
-		return nil, fmt.Errorf("no nodepools found")
+		klog.V(4).Info("No nodepools found")
+		return []*CoreWeaveNodePool{}, nil
 	}
 	klog.V(4).Infof("Found %d node pools", len(list.Items))
 	// Convert unstructured items to CoreWeaveNodePool instances
@@ -144,6 +145,8 @@ func (m *CoreWeaveManager) GetNodeGroup(nodePoolUID string) (cloudprovider.NodeG
 			return ng, nil
 		}
 	}
-	// If no node group is found, return an error
-	return nil, fmt.Errorf("node group for nodepool %s not found", nodePoolUID)
+	// If no node group is found, return nil (not an error) - this handles the case where
+	// nodes exist with CoreWeave labels but no corresponding node pools are configured
+	klog.V(4).Infof("No node group found for nodepool UID %s", nodePoolUID)
+	return nil, nil
 }

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager.go
@@ -122,7 +122,8 @@ func (m *CoreWeaveManager) UpdateNodeGroup() ([]cloudprovider.NodeGroup, error) 
 	// If no node pools are found, return an empty slice
 	if len(nodepools) == 0 {
 		klog.Info("No node pools found, returning empty node groups")
-		return []cloudprovider.NodeGroup{}, nil
+		m.nodeGroups = []cloudprovider.NodeGroup{}
+		return m.nodeGroups, nil
 	}
 	klog.V(4).Infof("Found %d node pools", len(nodepools))
 	m.nodeGroups = make([]cloudprovider.NodeGroup, len(nodepools))

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_manager_test.go
@@ -193,3 +193,36 @@ func TestListNodePools_EmptyList(t *testing.T) {
 		t.Errorf("expected empty nodepools list, got %d", len(nodePools))
 	}
 }
+
+func TestUpdateNodeGroup_EmptyNodePools(t *testing.T) {
+	// Create a nodepool with autoscaling disabled - this will result in empty list after filtering
+	obj := map[string]interface{}{
+		"apiVersion": coreWeaveGroup + "/" + coreWeaveVersion,
+		"kind":       coreWeaveResource,
+		"metadata": map[string]interface{}{
+			"name":      "np1",
+			"namespace": "default",
+			"uid":       "uid1",
+		},
+		"spec": map[string]interface{}{
+			"minNodes":    int64(1),
+			"maxNodes":    int64(5),
+			"targetNodes": int64(3),
+			"autoscaling": false, // Autoscaling disabled - will be filtered out
+		},
+	}
+	item := unstructured.Unstructured{Object: obj}
+	manager := makeTestManagerWithNodePools(nil, item)
+
+	// UpdateNodeGroup should return empty slice when all nodepools have autoscaling disabled
+	nodeGroups, err := manager.UpdateNodeGroup()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if nodeGroups == nil {
+		t.Error("expected empty slice, got nil")
+	}
+	if len(nodeGroups) != 0 {
+		t.Errorf("expected empty node groups, got %d", len(nodeGroups))
+	}
+}

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup.go
@@ -122,28 +122,8 @@ func (ng *CoreWeaveNodeGroup) Debug() string {
 
 // Nodes returns the list of nodes in the node group.
 func (ng *CoreWeaveNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
-	// Check if we have cached nodes
-	nodes, err := ng.getNodes()
-	if err != nil {
-		klog.Errorf("Failed to get nodes for node group %s: %v", ng.Name, err)
-		return nil, fmt.Errorf("failed to get nodes for node group %s: %v", ng.Name, err)
-	}
-	return nodes, nil
-}
-
-// getNodes returns the list of nodes in the node group.
-func (ng *CoreWeaveNodeGroup) getNodes() ([]cloudprovider.Instance, error) {
-	nodes, err := ng.nodepool.GetNodes()
-	if err != nil {
-		return nil, err
-	}
-	instances := make([]cloudprovider.Instance, len(nodes))
-	for i, node := range nodes {
-		instances[i] = cloudprovider.Instance{
-			Id: node.Name,
-		}
-	}
-	return instances, nil
+	// Return empty slice to avoid "not registered" warnings
+	return []cloudprovider.Instance{}, nil
 }
 
 // TemplateNodeInfo returns a template NodeInfo for the node group.

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_nodegroup_test.go
@@ -83,17 +83,6 @@ func TestId(t *testing.T) {
 	}
 }
 
-func TestNodes(t *testing.T) {
-	ng := makeTestNodeGroup("ng-1", "uid-1", 1, 5, 3)
-	nodes, err := ng.Nodes()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(nodes) != 2 {
-		t.Errorf("expected 2 nodes, got %d", len(nodes))
-	}
-}
-
 func TestMinMaxTargetSize(t *testing.T) {
 	ng := makeTestNodeGroup("ng-1", "uid-1", 2, 10, 5)
 	if ng.MinSize() != 2 {

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider_test.go
@@ -144,9 +144,12 @@ func TestCoreWeaveCloudProvider_NodeGroupForNode_GetNodePoolByNameError(t *testi
 	manager.UpdateNodeGroup()
 	cp := &CoreWeaveCloudProvider{manager: manager}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{coreWeaveNodePoolUID: "missing"}}}
-	_, err := cp.NodeGroupForNode(node)
-	if err == nil {
-		t.Error("expected error from GetNodePoolByName")
+	nodeGroup, err := cp.NodeGroupForNode(node)
+	if err != nil {
+		t.Errorf("unexpected error from NodeGroupForNode: %v", err)
+	}
+	if nodeGroup != nil {
+		t.Error("expected nil nodeGroup for non-existent nodepool UID")
 	}
 }
 
@@ -157,9 +160,12 @@ func TestCoreWeaveCloudProvider_NodeGroupForNode_GetNodePoolByUIDError(t *testin
 	manager.UpdateNodeGroup()
 	cp := &CoreWeaveCloudProvider{manager: manager}
 	node := &apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{coreWeaveNodePoolUID: "wrong-uid"}}}
-	_, err := cp.NodeGroupForNode(node)
-	if err == nil {
-		t.Error("expected error from GetNodePoolByUID")
+	nodeGroup, err := cp.NodeGroupForNode(node)
+	if err != nil {
+		t.Errorf("unexpected error from NodeGroupForNode: %v", err)
+	}
+	if nodeGroup != nil {
+		t.Error("expected nil nodeGroup for non-existent nodepool UID")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
Needs to return empty slice when nodepools autoscaling is disabled
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fix CA health check failure
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
